### PR TITLE
Add option to store pidfile in a different location

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,11 @@ If your organization uses a centralized log management product, see its document
     --hostname, Optionally set the 'Host' header (defaults to the host
     found in the server url).
 
-	--pid Generate pid file in current working directory
+	--pid, Generate pid file 'outsystemscc.pid' in current working directory.
+	Synonymous to --pidpath .
+
+	--pidpath, Generate pid file at a specific destination.
+	Set either path to a file, or a path to a directory.
 
     -v, Enable verbose logging
 

--- a/README.md
+++ b/README.md
@@ -185,11 +185,11 @@ If your organization uses a centralized log management product, see its document
     --hostname, Optionally set the 'Host' header (defaults to the host
     found in the server url).
 
-	--pid, Generate pid file 'outsystemscc.pid' in current working directory.
-	Synonymous to --pidpath .
+    --pid, Generate pid file 'outsystemscc.pid' in current working directory.
+    Synonymous to --pidpath .
 
-	--pidpath, Generate pid file at a specific destination.
-	Set either path to a file, or a path to a directory.
+    --pidpath, Generate pid file at a specific destination.
+    Set either path to a file, or a path to a directory.
 
     -v, Enable verbose logging
 


### PR DESCRIPTION
# Description
``--pid`` allows generation of a pidfile in the current directory, however that is not always suitable. In some cases, you may wish to store the pidfile in ``/var/run`` or other locations.

# What was happening?
Pid file was always stored in the current working directory

# What was done?
- Added a ``--pidpath`` option to store the pidfile in a different location
  - Passing a directory (e.g. ``/var/run``) will result in ``outsystemscc.pid`` being stored in that directory
  - Passing a file, or a path that does not currently exist (e.g. ``/var/run/odc.pid``) will result in the pid being stored at that filename
- Retained ``--pid`` functionality as to not break backwards compatibility
- ``--pid`` is now the same as ``--pidpath .``

# Test steps
- Run ``cloud-connector`` without any pid option, no pidfile should be created
- Run ``cloud-connector`` with ``--pid``, ``outsystemscc.pid`` should be created in the current working directory
- Run ``cloud-connector`` with ``--pidpath`` pointing to an existing directory, ``outsystemscc.pid`` should be created in the given directory
- Run ``cloud-connector`` with ``--pidpath`` pointing to an existing file, the pidfile should be written over that file
- Run ``cloud-connector`` with ``--pidpath`` pointing to an non-existing file, the pidfile should be written to that file
- Run ``cloud-connector`` with ``--pidpath`` pointing to an non-existing file within a directory that also does not exist, an error should be produced and the program should exit