### PR TITLE
Drop SetDoNotParseResponse in fetchURL -- connection leak

### DIFF
--- a/main.go
+++ b/main.go
@@ -207,7 +207,7 @@ func fetchURL(client *resty.Client, requestLocation string) string {
 		requestLocation = "http://" + requestLocation
 	}
 
-	resp, err := client.SetDoNotParseResponse(true).R().Get(requestLocation)
+	resp, err := client.R().Get(requestLocation)
 	if err != nil {
 		if resp != nil && resp.StatusCode() == http.StatusFound {
 			redirectURL := resp.Header().Get("Location")


### PR DESCRIPTION
The function ```fetchURL()``` only reads the response status and Location header -- it does not touch the body. ```SetDoNotParseResponse(true)``` tells resty not to drain or close the body for us, transferring that responsibility to the caller. 

```
// SetDoNotParseResponse method instructs Resty not to parse the response body automatically.
// Resty exposes the raw response body as [io.ReadCloser]. If you use it, do not
// forget to close the body, otherwise, you might get into connection leaks, and connection
// reuse may not happen.
//
// NOTE: [Response] middlewares are not executed using this option. You have
// taken over the control of response parsing from Resty.
func (c *Client) SetDoNotParseResponse(notParse bool) *Client {
	c.notParseResponse = notParse
	return c
}

```

Since we never close it, the body and its underlying socket stay open.

Removing the option lets resty handle body cleanup on its normal path.
No behavior change for callers; existing tests still pass.

If ```SetDoNotParseResponse``` is needed, that close can be added explicitly instead:

```
...
	resp, err := client.SetDoNotParseResponse(true).R().Get(requestLocation)
	if resp != nil {
		if body := resp.RawBody(); body != nil {
			defer body.Close()
		}
	}

...
```