### PR TITLE
Corelation logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,8 @@ If your organization uses a centralized log management product, see its document
         --pid Generate pid file in current working directory
 
         -v, Enable verbose logging
-
+        
+        --exlog, CLI flag that emits a structured, per-connection JSON log line for every connection forwarded through the tunnel. Each entry contains the route rule, destination, success flag, latency, duration, and bytes transferred in each direction. This answers the operational question: "Did we receive traffic for R:<port>:<host>:<port>, and was the forward to the target successful?"
         --help, This help text
 
     Signals:

--- a/exlog.go
+++ b/exlog.go
@@ -1,0 +1,299 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// exlogEntry is a structured per-connection record emitted when --exlog is
+// enabled. It is designed to answer the operational question:
+//
+//	"Did we receive traffic for R:<port>:<host>:<port>, and was the forward
+//	to the target successful?"
+//
+// Two entries are emitted per inbound connection received from the chisel
+// tunnel, sharing the same ConnID:
+//
+//	Event=="open"   when the connection is accepted from the tunnel.
+//	                Answers "did we receive traffic?" at arrival-time.
+//	Event=="close"  when the connection terminates.
+//	                Carries the dial outcome and transferred-byte counts.
+//
+// Within the exlog stream, ConnID joins the two events for a single TCP
+// connection. Across the chisel and exlog log streams, correlation is by
+// time proximity and order: chisel logs "client: tun: conn#N: Open"
+// immediately before dialling our local proxy, so its open event lands
+// right before our matching exlogEntry{Event:"open"}.
+type exlogEntry struct {
+	Timestamp   string `json:"timestamp"`
+	ConnID      uint64 `json:"conn_id"`
+	Event       string `json:"event"`           // "open" or "close"
+	RouteRule   string `json:"route_rule"`      // original "R:local:host:remote"
+	Destination string `json:"destination"`     // resolved "host:port" of target
+	SourceAddr  string `json:"source_addr"`     // remote addr of incoming conn (chisel side)
+	Success     bool   `json:"success"`         // close-only: did dial to target succeed?
+	LatencyMs   int64  `json:"latency_ms"`      // close-only: time to establish conn to target
+	DurationMs  int64  `json:"duration_ms"`     // close-only: total connection lifetime
+	BytesIn     int64  `json:"bytes_in"`        // close-only: bytes from tunnel -> target
+	BytesOut    int64  `json:"bytes_out"`       // close-only: bytes from target -> tunnel
+	Error       string `json:"error,omitempty"` // close-only: populated on failure
+}
+
+// nextConnID hands out monotonic identifiers used to tie the open/close
+// events for a single proxied connection together. Reset on process start.
+var nextConnID atomic.Uint64
+
+// exlogEmitter is the sink for exlog entries. Tests override this to capture
+// emitted records. The default writes a single tagged line per entry to the
+// standard logger so operators can grep / pipe through jq:
+//
+//	outsystemscc --exlog ... 2>&1 | grep '\[exlog\]' | sed 's/.*\[exlog\] //' | jq .
+var exlogEmitter = func(e exlogEntry) {
+	b, err := json.Marshal(e)
+	if err != nil {
+		log.Printf("[exlog] failed to marshal entry: %v", err)
+		return
+	}
+	log.Printf("[exlog] %s", string(b))
+}
+
+// exlogDialTimeout bounds how long we wait when dialing the target host.
+// Exposed as a var (rather than a const) so tests can shorten it.
+var exlogDialTimeout = 30 * time.Second
+
+// exlogProxy interposes on a single reverse remote. It accepts connections
+// from the chisel client and forwards them to the real target host:port,
+// recording a per-connection exlog entry on the way.
+type exlogProxy struct {
+	routeRule string       // original remote string, e.g. "R:8081:192.168.0.3:8393"
+	target    string       // dial address of the real target, "host:port"
+	listener  net.Listener // local TCP listener chisel will dial into
+}
+
+// startExlogProxies inspects each remote and, for every reverse TCP remote,
+// starts a local proxy on 127.0.0.1:<auto>. It returns a parallel slice of
+// remotes with the host/port rewritten to point at the local proxy. The
+// original local-port is preserved so that:
+//   - validateRemotes' duplicate-port check still applies
+//   - generateQueryParameters reports the correct ports to the server
+//   - operators see the same R:<local-port>:... values they configured
+//
+// Non-reverse remotes, UDP remotes, and any remote we cannot parse are
+// passed through unchanged with an informational log line.
+func startExlogProxies(remotes []string) ([]string, []*exlogProxy, error) {
+	rewritten := make([]string, 0, len(remotes))
+	proxies := make([]*exlogProxy, 0, len(remotes))
+
+	for _, r := range remotes {
+		spec, ok := parseReverseTCPRemote(r)
+		if !ok {
+			log.Printf("[exlog] skipping non-reverse-TCP remote (passthrough): %s", r)
+			rewritten = append(rewritten, r)
+			continue
+		}
+
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			// Best-effort cleanup of any proxies we already started.
+			for _, p := range proxies {
+				_ = p.listener.Close()
+			}
+			return nil, nil, fmt.Errorf("exlog: failed to start local proxy for %q: %w", r, err)
+		}
+
+		proxy := &exlogProxy{
+			routeRule: r,
+			target:    net.JoinHostPort(spec.targetHost, spec.targetPort),
+			listener:  ln,
+		}
+		proxies = append(proxies, proxy)
+		go proxy.serve()
+
+		_, proxyPort, _ := net.SplitHostPort(ln.Addr().String())
+		log.Printf("[exlog] proxy active: %s -> 127.0.0.1:%s -> %s", r, proxyPort, proxy.target)
+
+		rewritten = append(rewritten, fmt.Sprintf("R:%s:127.0.0.1:%s", spec.localPort, proxyPort))
+	}
+
+	return rewritten, proxies, nil
+}
+
+// stopExlogProxies closes all proxy listeners. Safe to call multiple times.
+func stopExlogProxies(proxies []*exlogProxy) {
+	for _, p := range proxies {
+		if p != nil && p.listener != nil {
+			_ = p.listener.Close()
+		}
+	}
+}
+
+func (p *exlogProxy) serve() {
+	for {
+		conn, err := p.listener.Accept()
+		if err != nil {
+			// Listener closed or temporary error. If it's permanent (closed
+			// listener) the loop exits naturally. If it were transient we'd
+			// see repeated errors -- log them quietly.
+			if errors.Is(err, net.ErrClosed) {
+				return
+			}
+			log.Printf("[exlog] accept error on %s: %v", p.routeRule, err)
+			return
+		}
+		go p.handle(conn)
+	}
+}
+
+// handle owns the lifecycle of a single proxied connection: emit an "open"
+// exlog entry on accept, dial the target, pipe data both directions, and
+// emit a matching "close" exlog entry on teardown. Both entries share the
+// same ConnID.
+func (p *exlogProxy) handle(client net.Conn) {
+	connID := nextConnID.Add(1)
+	sourceAddr := client.RemoteAddr().String()
+	start := time.Now()
+
+	// Open event: emitted immediately so an operator can confirm traffic
+	// arrived for this route without waiting for the connection to close.
+	exlogEmitter(exlogEntry{
+		Timestamp:   start.UTC().Format(time.RFC3339Nano),
+		ConnID:      connID,
+		Event:       "open",
+		RouteRule:   p.routeRule,
+		Destination: p.target,
+		SourceAddr:  sourceAddr,
+	})
+
+	// Close event: built up below; emitted exactly once on return.
+	closeEntry := exlogEntry{
+		ConnID:      connID,
+		Event:       "close",
+		RouteRule:   p.routeRule,
+		Destination: p.target,
+		SourceAddr:  sourceAddr,
+	}
+	defer func() {
+		closeEntry.Timestamp = time.Now().UTC().Format(time.RFC3339Nano)
+		closeEntry.DurationMs = time.Since(start).Milliseconds()
+		exlogEmitter(closeEntry)
+	}()
+	defer client.Close()
+
+	dialStart := time.Now()
+	target, err := net.DialTimeout("tcp", p.target, exlogDialTimeout)
+	closeEntry.LatencyMs = time.Since(dialStart).Milliseconds()
+	if err != nil {
+		closeEntry.Success = false
+		closeEntry.Error = err.Error()
+		return
+	}
+	defer target.Close()
+	closeEntry.Success = true
+
+	var bytesIn, bytesOut int64
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// tunnel -> target  (request bytes)
+	go func() {
+		defer wg.Done()
+		n, _ := io.Copy(target, client)
+		atomic.StoreInt64(&bytesIn, n)
+		// Half-close so the target sees EOF and can flush its response.
+		if tc, ok := target.(*net.TCPConn); ok {
+			_ = tc.CloseWrite()
+		}
+	}()
+
+	// target -> tunnel  (response bytes)
+	go func() {
+		defer wg.Done()
+		n, _ := io.Copy(client, target)
+		atomic.StoreInt64(&bytesOut, n)
+		if tc, ok := client.(*net.TCPConn); ok {
+			_ = tc.CloseWrite()
+		}
+	}()
+
+	wg.Wait()
+	closeEntry.BytesIn = atomic.LoadInt64(&bytesIn)
+	closeEntry.BytesOut = atomic.LoadInt64(&bytesOut)
+}
+
+// remoteSpec is the subset of a chisel remote definition we care about for exlog purposes.
+type remoteSpec struct {
+	localHost  string // optional, defaults to ""
+	localPort  string
+	targetHost string
+	targetPort string
+}
+
+// parseReverseTCPRemote understands the chisel remote forms we record:
+//
+//	R:<local-port>:<host>:<remote-port>
+//	R:<local-host>:<local-port>:<host>:<remote-port>
+//
+// It deliberately rejects anything ending in /udp (chisel's UDP marker) and
+// any non-reverse form (no leading "R:"). When ok is false, callers should
+// pass the remote through to chisel unchanged.
+func parseReverseTCPRemote(r string) (spec remoteSpec, ok bool) {
+	if !strings.HasPrefix(r, "R:") {
+		return spec, false
+	}
+	body := strings.TrimPrefix(r, "R:")
+
+	// Reject explicit UDP markers - we only record TCP.
+	if strings.Contains(body, "/udp") {
+		return spec, false
+	}
+	// Strip a /tcp suffix if present, it doesn't change semantics.
+	body = strings.TrimSuffix(body, "/tcp")
+
+	parts := strings.Split(body, ":")
+	switch len(parts) {
+	case 3:
+		// <local-port>:<remote-host>:<remote-port>
+		spec.localPort = parts[0]
+		spec.targetHost = parts[1]
+		spec.targetPort = parts[2]
+	case 4:
+		// <local-host>:<local-port>:<remote-host>:<remote-port>
+		spec.localHost = parts[0]
+		spec.localPort = parts[1]
+		spec.targetHost = parts[2]
+		spec.targetPort = parts[3]
+	default:
+		return spec, false
+	}
+
+	// Sanity-check the ports are numeric. chisel will validate more
+	// strictly later; we only need enough certainty to safely build
+	// our proxy address.
+	if !isNumericPort(spec.localPort) || !isNumericPort(spec.targetPort) {
+		return spec, false
+	}
+	if spec.targetHost == "" {
+		return spec, false
+	}
+	return spec, true
+}
+
+func isNumericPort(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, c := range s {
+		if c < '0' || c > '9' {
+			return false
+		}
+	}
+	return true
+}

--- a/exlog_test.go
+++ b/exlog_test.go
@@ -1,0 +1,295 @@
+package main
+
+import (
+	"io"
+	"net"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// captureExlogEmitter swaps the package-level exlogEmitter for a thread-safe
+// recorder for the duration of a test, returning a getter and a restore fn.
+func captureExlogEmitter(t *testing.T) (func() []exlogEntry, func()) {
+	t.Helper()
+	orig := exlogEmitter
+	var mu sync.Mutex
+	var got []exlogEntry
+	exlogEmitter = func(e exlogEntry) {
+		mu.Lock()
+		defer mu.Unlock()
+		got = append(got, e)
+	}
+	return func() []exlogEntry {
+			mu.Lock()
+			defer mu.Unlock()
+			out := make([]exlogEntry, len(got))
+			copy(out, got)
+			return out
+		}, func() {
+			exlogEmitter = orig
+		}
+}
+
+// startEchoServer starts a TCP server that echoes one read back and returns
+// its listen address. It runs until the test ends.
+func startEchoServer(t *testing.T) net.Listener {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("echo listen: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer c.Close()
+				buf := make([]byte, 1024)
+				n, err := c.Read(buf)
+				if err != nil {
+					return
+				}
+				_, _ = c.Write(buf[:n])
+			}(c)
+		}
+	}()
+	return ln
+}
+
+func Test_parseReverseTCPRemote(t *testing.T) {
+	tests := []struct {
+		in       string
+		wantOK   bool
+		wantHost string
+		wantPort string
+	}{
+		{"R:8081:192.168.0.3:8393", true, "192.168.0.3", "8393"},
+		{"R:127.0.0.1:8081:internal:443", true, "internal", "443"},
+		{"R:8081:host:8393/tcp", true, "host", "8393"},
+		{"R:8081:host:8393/udp", false, "", ""},
+		{"8081:host:8393", false, "", ""},  // not reverse
+		{"R:abc:host:8393", false, "", ""}, // non-numeric local port
+		{"R:8081:host:xyz", false, "", ""}, // non-numeric remote port
+		{"R:8081", false, "", ""},          // too few parts
+		{"R::host:8393", false, "", ""},    // empty local port
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			got, ok := parseReverseTCPRemote(tt.in)
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tt.wantOK)
+			}
+			if !ok {
+				return
+			}
+			if got.targetHost != tt.wantHost {
+				t.Errorf("targetHost = %q, want %q", got.targetHost, tt.wantHost)
+			}
+			if got.targetPort != tt.wantPort {
+				t.Errorf("targetPort = %q, want %q", got.targetPort, tt.wantPort)
+			}
+		})
+	}
+}
+
+func Test_startExlogProxies_passthrough(t *testing.T) {
+	// UDP and non-reverse remotes should be passed through unchanged so that
+	// chisel can handle (or reject) them as it normally would.
+	in := []string{
+		"R:8081:host:8393/udp",
+		"8081:host:8393",
+		"R:8082:host:8393",
+	}
+	out, proxies, err := startExlogProxies(in)
+	if err != nil {
+		t.Fatalf("startExlogProxies: %v", err)
+	}
+	t.Cleanup(func() { stopExlogProxies(proxies) })
+
+	if len(out) != 3 {
+		t.Fatalf("len(out) = %d, want 3", len(out))
+	}
+	if out[0] != in[0] {
+		t.Errorf("UDP remote was rewritten: %q", out[0])
+	}
+	if out[1] != in[1] {
+		t.Errorf("non-reverse remote was rewritten: %q", out[1])
+	}
+	// The third one *should* be rewritten to point at the local proxy.
+	if !strings.HasPrefix(out[2], "R:8082:127.0.0.1:") {
+		t.Errorf("expected reverse remote to be rewritten, got %q", out[2])
+	}
+	if len(proxies) != 1 {
+		t.Errorf("expected 1 active proxy, got %d", len(proxies))
+	}
+}
+
+func Test_exlogProxy_successfulForward(t *testing.T) {
+	getEntries, restore := captureExlogEmitter(t)
+	defer restore()
+
+	echo := startEchoServer(t)
+	echoAddr := echo.Addr().String()
+	host, port, _ := net.SplitHostPort(echoAddr)
+
+	original := "R:9999:" + host + ":" + port
+	rewritten, proxies, err := startExlogProxies([]string{original})
+	if err != nil {
+		t.Fatalf("startExlogProxies: %v", err)
+	}
+	defer stopExlogProxies(proxies)
+
+	// Extract the proxy address from the rewritten remote: R:9999:127.0.0.1:<proxy>
+	parts := strings.Split(rewritten[0], ":")
+	if len(parts) != 4 {
+		t.Fatalf("unexpected rewritten form: %s", rewritten[0])
+	}
+	proxyAddr := net.JoinHostPort(parts[2], parts[3])
+
+	// Simulate chisel delivering a tunnel connection to our proxy.
+	conn, err := net.Dial("tcp", proxyAddr)
+	if err != nil {
+		t.Fatalf("dial proxy: %v", err)
+	}
+	payload := []byte("hello-exlog")
+	if _, err := conn.Write(payload); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	// Half-close so the echo server returns and our proxy goroutines unwind.
+	if tc, ok := conn.(*net.TCPConn); ok {
+		_ = tc.CloseWrite()
+	}
+	// Read echoed bytes.
+	got, err := io.ReadAll(conn)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(got) != string(payload) {
+		t.Errorf("echo mismatch: got %q, want %q", got, payload)
+	}
+	_ = conn.Close()
+
+	// Wait for both exlog entries (open + close) to be emitted.
+	deadline := time.Now().Add(2 * time.Second)
+	var entries []exlogEntry
+	for time.Now().Before(deadline) {
+		entries = getEntries()
+		if len(entries) >= 2 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 exlog entries (open+close), got %d", len(entries))
+	}
+
+	open, closed := entries[0], entries[1]
+	if open.Event != "open" {
+		t.Errorf("entries[0].Event = %q, want %q", open.Event, "open")
+	}
+	if closed.Event != "close" {
+		t.Errorf("entries[1].Event = %q, want %q", closed.Event, "close")
+	}
+	if open.ConnID == 0 {
+		t.Errorf("ConnID should be non-zero")
+	}
+	if open.ConnID != closed.ConnID {
+		t.Errorf("conn_id mismatch: open=%d close=%d", open.ConnID, closed.ConnID)
+	}
+	if open.SourceAddr != closed.SourceAddr {
+		t.Errorf("source_addr mismatch between open and close events")
+	}
+	if open.RouteRule != original {
+		t.Errorf("open.RouteRule = %q, want %q", open.RouteRule, original)
+	}
+	if closed.Destination != echoAddr {
+		t.Errorf("close.Destination = %q, want %q", closed.Destination, echoAddr)
+	}
+	if !closed.Success {
+		t.Errorf("close.Success = false, want true; error=%q", closed.Error)
+	}
+	if closed.BytesIn != int64(len(payload)) {
+		t.Errorf("BytesIn = %d, want %d", closed.BytesIn, len(payload))
+	}
+	if closed.BytesOut != int64(len(payload)) {
+		t.Errorf("BytesOut = %d, want %d", closed.BytesOut, len(payload))
+	}
+	if open.Timestamp == "" || closed.Timestamp == "" {
+		t.Errorf("Timestamp empty (open=%q close=%q)", open.Timestamp, closed.Timestamp)
+	}
+	if closed.LatencyMs < 0 {
+		t.Errorf("LatencyMs negative: %d", closed.LatencyMs)
+	}
+}
+
+func Test_exlogProxy_targetUnreachable(t *testing.T) {
+	getEntries, restore := captureExlogEmitter(t)
+	defer restore()
+
+	// Reserve a port and immediately close it so the target is guaranteed
+	// to refuse connections.
+	tmp, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserve: %v", err)
+	}
+	deadAddr := tmp.Addr().String()
+	host, port, _ := net.SplitHostPort(deadAddr)
+	_ = tmp.Close()
+
+	// Tighten the dial timeout so the test stays fast even on slow CI.
+	origTimeout := exlogDialTimeout
+	exlogDialTimeout = 500 * time.Millisecond
+	defer func() { exlogDialTimeout = origTimeout }()
+
+	original := "R:9998:" + host + ":" + port
+	rewritten, proxies, err := startExlogProxies([]string{original})
+	if err != nil {
+		t.Fatalf("startExlogProxies: %v", err)
+	}
+	defer stopExlogProxies(proxies)
+
+	parts := strings.Split(rewritten[0], ":")
+	proxyAddr := net.JoinHostPort(parts[2], parts[3])
+
+	conn, err := net.Dial("tcp", proxyAddr)
+	if err != nil {
+		t.Fatalf("dial proxy: %v", err)
+	}
+	// On a closed target the proxy will close us right back.
+	_, _ = io.ReadAll(conn)
+	_ = conn.Close()
+
+	deadline := time.Now().Add(2 * time.Second)
+	var entries []exlogEntry
+	for time.Now().Before(deadline) {
+		entries = getEntries()
+		if len(entries) >= 2 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 exlog entries (open+close), got %d", len(entries))
+	}
+	open, closed := entries[0], entries[1]
+	if open.Event != "open" || closed.Event != "close" {
+		t.Fatalf("unexpected event sequence: open=%q close=%q", open.Event, closed.Event)
+	}
+	if open.ConnID != closed.ConnID || open.ConnID == 0 {
+		t.Errorf("conn_id mismatch or zero: open=%d close=%d", open.ConnID, closed.ConnID)
+	}
+	if closed.Success {
+		t.Errorf("close.Success = true, want false")
+	}
+	if closed.Error == "" {
+		t.Errorf("close.Error empty, want a dial failure message")
+	}
+	if closed.BytesIn != 0 || closed.BytesOut != 0 {
+		t.Errorf("expected zero bytes on failure, got in=%d out=%d", closed.BytesIn, closed.BytesOut)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -106,6 +106,22 @@ var clientHelp = `
 
 	--pid Generate pid file in current working directory
 
+<<<<<<< Updated upstream
+=======
+    --exlog, Emit a structured per-connection extra log to stderr in addition
+    to the normal output. Two entries are emitted per connection, both tagged
+    "[exlog]" followed by JSON, sharing the same conn_id:
+        - event="open"  emitted immediately on accept; answers
+                         "did we receive traffic for this route?"
+        - event="close" emitted on teardown; carries success flag, latency,
+                         duration, and bytes transferred each direction.
+    Within the exlog stream, conn_id ties the pair together. Across the
+    chisel and exlog streams, correlation is by time and order: chisel logs
+    "client: tun: conn#N: Open" immediately before our matching open event.
+    Pipe through jq for analysis, e.g.:
+        outsystemscc --exlog ... 2>&1 | grep '\[exlog\]' | sed 's/.*\[exlog\] //' | jq .
+
+>>>>>>> Stashed changes
     -v, Enable verbose logging
 
     --help, This help text

--- a/main.go
+++ b/main.go
@@ -106,8 +106,6 @@ var clientHelp = `
 
 	--pid Generate pid file in current working directory
 
-<<<<<<< Updated upstream
-=======
     --exlog, Emit a structured per-connection extra log to stderr in addition
     to the normal output. Two entries are emitted per connection, both tagged
     "[exlog]" followed by JSON, sharing the same conn_id:
@@ -121,7 +119,6 @@ var clientHelp = `
     Pipe through jq for analysis, e.g.:
         outsystemscc --exlog ... 2>&1 | grep '\[exlog\]' | sed 's/.*\[exlog\] //' | jq .
 
->>>>>>> Stashed changes
     -v, Enable verbose logging
 
     --help, This help text
@@ -145,6 +142,7 @@ func client(args []string) {
 	flags.Var(&headerFlags{config.Headers}, "header", "")
 	hostname := flags.String("hostname", "", "Deprecated, will be ignored")
 	pid := flags.Bool("pid", false, "")
+	exlog := flags.Bool("exlog", false, "")
 	verbose := flags.Bool("v", false, "")
 	flags.Usage = func() {
 		fmt.Print(clientHelp)
@@ -174,7 +172,24 @@ func client(args []string) {
 	serverURL := fetchURL(createHTTPClient(&config), args[0])
 
 	config.Server = fmt.Sprintf("%s%s", serverURL, queryParams)
-	config.Remotes = args[1:]
+
+	// If --exlog is set, interpose a local TCP proxy on each reverse remote
+	// so we can record per-connection metrics. The local-port the operator
+	// configured stays the same; only the host:port chisel dials gets
+	// rewritten to point at 127.0.0.1:<auto-allocated>.
+	remotes := args[1:]
+	if *exlog {
+		log.Printf("[exlog] mode enabled - emitting per-connection records as [exlog] <json>")
+		rewritten, proxies, err := startExlogProxies(remotes)
+		if err != nil {
+			log.Fatal(err)
+		}
+		// Tear down listeners on shutdown. cos.InterruptContext cancels on
+		// SIGINT/SIGTERM; once chisel.Wait returns we close the proxies.
+		defer stopExlogProxies(proxies)
+		remotes = rewritten
+	}
+	config.Remotes = remotes
 
 	//default auth
 	if config.Auth == "" {


### PR DESCRIPTION
FixBugCorrelationLogs Open And Close Connection associated ID:

2026/05/08 16:49:04 client: tun: conn#3: Open [1/3]
2026/05/08 16:49:04 [exlog] {"timestamp":"2026-05-08T15:49:04.320366541Z","conn_id":3,"event":"open","route_rule":"R:8081:catfact.ninja:443","destination":"catfact.ninja:443","source_addr":"127.0.0.1:38382","success":false,"latency_ms":0,"duration_ms":0,"bytes_in":0,"bytes_out":0}
2026/05/08 16:50:19 client: tun: conn#3: sent 565B received 6.21KB
2026/05/08 16:50:19 client: tun: conn#3: Close [0/3]
2026/05/08 16:50:19 [exlog] {"timestamp":"2026-05-08T15:50:19.370501906Z","conn_id":3,"event":"close","route_rule":"R:8081:catfact.ninja:443","destination":"catfact.ninja:443","source_addr":"127.0.0.1:38382","success":true,"latency_ms":149,"duration_ms":75050,"bytes_in":565,"bytes_out":6214}