### PR TITLE
DX-412: Add Claude Code instructions distilled from this repo's merged PRs

### DIFF
--- a/.claude/rules/versioning.md
+++ b/.claude/rules/versioning.md
@@ -1,0 +1,22 @@
+---
+paths:
+  - "main.go"
+  - ".goreleaser.yaml"
+---
+
+<!-- Proposed from inner-sourcing analysis of merged PR #138 — edit freely. -->
+
+# Versioning: `main.version` is only real in release builds
+
+`main.go` declares `var version = "dev" // Set by goreleaser`. In source, in `go run`, and in any plain `go build`, `version` stays `"dev"`. A real version string can only come from the release pipeline (`.goreleaser.yaml` -> the Docker image published to GHCR) injecting it at link time — and only when `.goreleaser.yaml` is actually configured to do so.
+
+Treat the `// Set by goreleaser` comment as a claim to verify, not a guarantee. Injection requires `-X main.version={{ .Version }}` in the build entry's `ldflags` in `.goreleaser.yaml`. **At HEAD that linker flag is absent**: PR #138 added `ldflags: ["-s -w -X main.version={{ .Version }}"]`, but commit 5419c5f ("dependabot updates and go version bump") removed it, so the current build entry carries no `ldflags` at all. As a result every released client currently reports `dev` — the failure mode below is live, not hypothetical. Adding custom `ldflags`/`flags` to the build without re-adding `-X main.version=...` keeps injection dropped.
+
+## When you make `version` load-bearing
+
+`version` is already load-bearing: `main.go` sets the connection `User-Agent` to `CloudConnector/<version>` so Support can identify the client version from access logs. If you surface `version` anywhere else production depends on — a request header, a log line, a metric, anything Support/ops reads off the wire (not just the `--help` text) — you MUST confirm the release build actually injects it:
+
+- Open `.goreleaser.yaml` and check the build entry explicitly carries `-X main.version={{ .Version }}` in its `ldflags`. Add it back if it's missing (it is, at HEAD). Do not rely on it being injected implicitly.
+- Understand the failure mode: it is silent. The code compiles, `go test` passes (it runs against `"dev"`), and the header/log is emitted — yet every released client advertises `CloudConnector/dev`, making the value useless. Unit tests cannot catch this; only a release/snapshot build can. Verify with `goreleaser --clean --snapshot` (or the published image) and inspect the actual emitted value, not just `go test`.
+
+Keep the source default `"dev"` — it is the correct sentinel for local/dev runs.

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ rules/
 .markdownlint.json
 .vale.ini
 outsystemscc
+.claude/*
+!.claude/rules/


### PR DESCRIPTION
## What this is

We ran 5 of this repository's recently merged PRs through an analysis loop: Claude Code implemented each ticket autonomously from the same starting commit your team had, and a reviewer step compared its implementation and reasoning against your merged result to find the repository knowledge it was missing. The files in this PR are the instructions that would have closed those gaps — so that future AI-assisted work in this repo starts with your team's knowledge instead of rediscovering (or missing) it.

All assets were additionally fact-checked against this repository's current state (commit `2def1a5e3`, 2026-06-11) shortly before this PR was opened.

Every asset below explains the concrete evidence it came from. Please treat this as a proposal: take what's useful, edit freely, drop the rest.

## Proposed assets

| # | Asset | Target | Evidence |
|---|-------|--------|----------|
| C2 | Confirm goreleaser injects main.version before relying on it at runtime | `.claude/rules/versioning.md` | #138 |

### C2 — Confirm goreleaser injects main.version before relying on it at runtime

**File:** `.claude/rules/versioning.md` · **Evidence:** #138

<details><summary>Why this asset — the full reasoning</summary>
<br>

This repo emits a real client `version` only in artifacts built by the release pipeline. `main.go` declares `var version = "dev" // Set by goreleaser`, and in source, `go run`, or any plain `go build` it stays `dev`. PR #138 made `version` load-bearing by putting it into the connection's `User-Agent` header (`CloudConnector/<version>`) so Support can identify which Cloud Connector version a customer runs from Gloo/CloudFront access logs. PR #138 also added explicit `-X main.version={{ .Version }}` linker flags to `.goreleaser.yaml`'s build entry so releases would carry a real version — but commit 5419c5f ("dependabot updates and go version bump") later removed those `ldflags`, and at HEAD the build entry carries none. The coupling is non-obvious and the failure mode is silent: with the ldflags gone, the code still compiles and `go test` still passes (tests run against the `dev` default), yet every released client now advertises `CloudConnector/dev` to the access logs, defeating the header's whole purpose. Unit tests cannot catch this; only a release or snapshot build can. This rule captures the coupling so any change that relies on `version` confirms build-time injection is actually present (re-adding the ldflag where it has been dropped), and keeps `dev` as the correct sentinel for local runs.

</details>

## Also in this PR: versioning `.claude/rules/`

This repo's `.gitignore` previously excluded the whole `.claude/` directory, which would keep the path-scoped rules above from being versioned or shared. We narrowed it (`.claude/*` + `!.claude/rules/`) so the rules travel with the repo — everything else under `.claude/` (personal/local files) stays ignored.
