### PR TITLE
TK-22180 docs: clarify that remote-host accepts hostnames and FQDNs

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -27,6 +27,8 @@ The key parameters used in the command:
 * `--image ghcr.io/outsystems/outsystemscc`: Specifies the Docker image to use for the container instance.
 * `--command-line '...'`: Specifies the command line to run in the container. This command starts the `outsystemscc` service with the specified header token, server URL, and remote connection details.
 
+The `<remote-host>` value in the remote connection (for example, `192.168.0.3` above) accepts a static IP address or a hostname/FQDN.
+
 Ensure to replace `[ResourceGroupName]`, `[ContainerName]`, and the values in the `--command-line` parameter with your actual values.
 
 #### Azure configuration page

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Use the **Token** and **Address** to form the `outsystemscc` command to run. For
       https://organization.outsystems.app/sg_6c23a5b4-b718-4634-a503-f22aed17d4e7 \
       R:8081:192.168.0.3:8393
 
-In this example, you create a tunnel to the endpoint `192.168.0.3:8393`, a REST API service running on IP address `192.168.0.3`. The endpoint is available to consume by apps running in the connected stage at `secure-gateway:8081`.
+In this example, you create a tunnel to the endpoint `192.168.0.3:8393`, a REST API service. The endpoint is available to consume by apps running in the connected stage at `secure-gateway:8081`. The `<remote-host>` field accepts a static IP address or a hostname/FQDN, for example `db.internal.example.com`.
 
 > :bulb: If you want to run `outsystemscc` on Azure Container Instances, [see the FAQs](FAQ.md#how-do-i-run-outsystemscc-on-azure-container-instances) for specific guidance.
 
@@ -154,7 +154,7 @@ You can create a tunnel to connect multiple endpoints to the same Private Gatewa
 
 In the above example you create a tunnel to connect two endpoints. One, as before, `192.168.0.3:8393`, a REST API service running on IP address `192.168.0.3`. The endpoint is available for use by apps running in the connected stage at `secure-gateway:8081`. Second, `192.168.0.4:587`, an SMTP server running on `192.168.0.4`, another IP in the internal address range. The endpoint is available for use by apps running in the connected stage at `secure-gateway:8082`.
 
-You can create a tunnel to any endpoint that's in the internal address range and so is network accessible over TCP or UDP from the system on which `outsystemscc` is run. If the connection is over UDP, add `/udp` to the end of the remote port.
+You can create a tunnel to any endpoint that's network accessible over TCP or UDP from the system on which `outsystemscc` is run, whether identified by IP address or hostname/FQDN. If the connection is over UDP, add `/udp` to the end of the remote port.
 
 To learn more about using connected endpoints in app development go to the [ODC documentation site](https://www.outsystems.com/goto/secure-gateways). Be sure to share the list of connected endpoint(s) of the form `secure-gateway:<port>` and any associated swagger specification file(s) with members of your team responsible developing apps in ODC Studio.
 
@@ -199,6 +199,9 @@ If your organization uses a centralized log management product, see its document
 
         R:8081:192.168.0.3:8393
         R:8082:192.168.0.4:587
+        R:8083:db.internal.example.com:5432
+
+        <remote-host> accepts a static IP address or a hostname/FQDN.
 
         See https://github.com/OutSystems/cloud-connector for examples in context.
         


### PR DESCRIPTION
## Summary

All examples in `README.md` and `FAQ.md` used static IP addresses exclusively in the `R:<local-port>:<remote-host>:<remote-port>` syntax. This created the impression that `<remote-host>` only accepts IP addresses, when in fact it accepts any value that is network-reachable from the machine running `outsystemscc` — including hostnames and FQDNs.

This is particularly relevant for cloud-hosted services (for example, Azure services) that do not guarantee static IPs. Customers who are unaware that FQDNs work may believe they need to set up an intermediary API gateway just to obtain a fixed address, which is unnecessary complexity.

Reference: https://outsystems.slack.com/archives/CK3LCTELU/p1781616006171719

## Changes

* **README.md** — Updated the single-endpoint example description to state that `<remote-host>` accepts a static IP address or a hostname/FQDN. Added a hostname example (`db.internal.example.com`) to the detailed options section. Removed the phrase "in the internal address range" from the network accessibility note, which incorrectly implied only IP-range endpoints are supported.
* **FAQ.md** — Added a note to the Azure Container Instances section clarifying that the remote-host value accepts a static IP address or hostname/FQDN.

Also added similar clarifications in the ODC docs repo at PR https://github.com/OutSystems/docs-next/pull/2680