### PR TITLE
RDODCP-918: Bump chisel to v1.11.8-os.1, update deps and Go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/outsystems/cloud-connector
 require (
 	github.com/go-resty/resty/v2 v2.17.2
 	github.com/jarcoal/httpmock v1.4.1
-	github.com/jpillora/chisel v1.10.1
+	github.com/jpillora/chisel v1.11.8
 )
 
 require (
@@ -13,11 +13,11 @@ require (
 	github.com/jpillora/backoff v1.0.0 // indirect
 	github.com/jpillora/sizestr v1.0.0 // indirect
 	golang.org/x/crypto v0.53.0 // indirect
-	golang.org/x/net v0.55.0 // indirect
+	golang.org/x/net v0.56.0 // indirect
 	golang.org/x/sync v0.21.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect
 )
 
-replace github.com/jpillora/chisel => github.com/outsystems/chisel v1.11.5-os.4
+replace github.com/jpillora/chisel => github.com/outsystems/chisel v1.11.8-os.1
 
-go 1.26.4
+go 1.26.5

--- a/go.sum
+++ b/go.sum
@@ -16,12 +16,12 @@ github.com/jpillora/sizestr v1.0.0 h1:4tr0FLxs1Mtq3TnsLDV+GYUWG7Q26a6s+tV5Zfw2yg
 github.com/jpillora/sizestr v1.0.0/go.mod h1:bUhLv4ctkknatr6gR42qPxirmd5+ds1u7mzD+MZ33f0=
 github.com/maxatome/go-testdeep v1.14.0 h1:rRlLv1+kI8eOI3OaBXZwb3O7xY3exRzdW5QyX48g9wI=
 github.com/maxatome/go-testdeep v1.14.0/go.mod h1:lPZc/HAcJMP92l7yI6TRz1aZN5URwUBUAfUNvrclaNM=
-github.com/outsystems/chisel v1.11.5-os.4 h1:6xOWEciQpLIIuzz7PdC1urBTqlbwlWDqTUJUsx+UoTA=
-github.com/outsystems/chisel v1.11.5-os.4/go.mod h1:cB4jnXiuRWz822DQvXCeFphjxPqpd7vvSiViXParmwM=
+github.com/outsystems/chisel v1.11.8-os.1 h1:IBVdS3p48SJqsqchK1NzQHU/zWmM4BS9bcfQIZzpIHQ=
+github.com/outsystems/chisel v1.11.8-os.1/go.mod h1:ttOXpWYooU2+yBUsuhu6B0kLNI31ULUxwSRkITid1EY=
 golang.org/x/crypto v0.53.0 h1:QZ4Muo8THX6CizN2vPPd5fBGHyogrdK9fG4wLPFUsto=
 golang.org/x/crypto v0.53.0/go.mod h1:DNLU434OwVakk9PzuwV8w62mAJpRJL3vsgcfp4Qnsio=
-golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=
-golang.org/x/net v0.55.0/go.mod h1:L5U2KuzuOe1lY7Z+aWVIKK6qEeJXnXV9yzGA+WCHJww=
+golang.org/x/net v0.56.0 h1:Rw8j/hFzGvJUZwNBXnAtf5sVDVt+65SK2C7IxCxZt5o=
+golang.org/x/net v0.56.0/go.mod h1:D3Ku6r+V6JROoZK144D2XfMHFcMq/0zSfLelVTCFKec=
 golang.org/x/sync v0.21.0 h1:HLII4xRRTtCRkxYp4HNFF0Js/Og6q2i++KXbg0gHCwM=
 golang.org/x/sync v0.21.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.46.0 h1:noSf2Fq6F8DBgS+LysIkx7rIExoNHJsxOAtPp4rthXw=


### PR DESCRIPTION
## Summary

This PR updates the Cloud Connector's `chisel` dependency to pick up the latest OutSystems fork release, along with routine Go and dependency maintenance.

---

## Chisel Update (`v1.11.5-os.4` → `v1.11.8-os.1`)

Picks up the following changes from the upstream sync (`jpillora/chisel v1.11.7`):

*   **Fix race in tunnel waitGroup causing negative counter panic** ([jpillora/chisel#586](https://github.com/jpillora/chisel/pull/586))
    *   Resolves a race condition that could cause a negative counter panic under concurrent connection teardown.
*   **Improve SOCKS auth: enforce per-user ACL on SOCKS channels** ([jpillora/chisel#591](https://github.com/jpillora/chisel/pull/591))
    *   Enforces per-user address ACLs on post-handshake SOCKS proxy channels, preventing ACL bypass via SSH channel injection.
*   **Wire Verbose flag to client logger level** ([jpillora/chisel#281](https://github.com/jpillora/chisel/pull/281))
    *   The `Verbose` field in the client `Config` was present but unused. It now correctly controls the logger's info level.

---

## Dependency Updates

*   **golang.org/x/net:** `v0.55.0` → `v0.56.0`
*   **Go version:** `1.26.4` → `1.26.5`